### PR TITLE
Enhance PIL compressor options

### DIFF
--- a/utils/compressor_engine_pil.py
+++ b/utils/compressor_engine_pil.py
@@ -7,6 +7,9 @@ import os
 import time
 import uuid
 import logging
+from dataclasses import dataclass, replace
+from typing import Dict, Optional, Tuple
+
 import pythoncom
 from PIL import Image, ImageGrab
 
@@ -163,7 +166,133 @@ def _apply_props_to_picture(pic, props):
     except Exception as e:
         logging.warning(f"    -> Lỗi khi áp dụng hyperlink: {e}")
 
-def _export_and_replace(shape, sheet, quality=70, mode='auto', keep_dpi=96):
+@dataclass(frozen=True)
+class CompressionOptions:
+    """Tập hợp các tùy chọn nén ảnh.
+
+    Các trường được giữ đơn giản để vẫn tương thích với tham số cũ:
+    - ``mode``: chiến lược chọn định dạng đầu ra.
+    - ``jpeg_quality``/``jpeg_optimize``/``jpeg_progressive``: cấu hình JPEG.
+    - ``jpeg_background``: màu nền dùng để làm phẳng lớp alpha khi ép sang JPEG.
+    - ``png_optimize``/``png_colors``/``png_compress_level``: cấu hình PNG.
+    - ``webp_quality``/``webp_lossless``: cấu hình WebP (nếu được chọn).
+    - ``keep_dpi``: đặt DPI cho ảnh đầu ra; ``None`` để giữ nguyên.
+    - ``max_width``/``max_height``: thu nhỏ ảnh khi lớn hơn kích thước chỉ định.
+    - ``resize_filter``: bộ lọc nội suy (Pillow constant, ví dụ ``Image.LANCZOS``).
+    - ``strip_metadata``: loại bỏ EXIF/IPTC để giảm dung lượng.
+    """
+
+    mode: str = "auto"
+    jpeg_quality: int = 70
+    jpeg_optimize: bool = True
+    jpeg_progressive: bool = True
+    jpeg_background: Optional[Tuple[int, int, int]] = (255, 255, 255)
+    png_optimize: bool = True
+    png_colors: Optional[int] = 256
+    png_compress_level: int = 9
+    webp_quality: int = 75
+    webp_lossless: bool = False
+    keep_dpi: Optional[int] = 96
+    max_width: Optional[int] = None
+    max_height: Optional[int] = None
+    resize_filter: int = Image.LANCZOS
+    strip_metadata: bool = True
+
+    @staticmethod
+    def from_legacy(quality: int = 70, mode: str = "auto", keep_dpi: Optional[int] = 96, **kwargs) -> "CompressionOptions":
+        """Tạo ``CompressionOptions`` từ tham số cũ của ``compress_images``."""
+
+        opts = CompressionOptions(mode=mode, keep_dpi=keep_dpi, **kwargs)
+        if mode in ("jpeg", "auto"):
+            opts = replace(opts, jpeg_quality=quality)
+        elif mode == "png":
+            # Với PNG ta map quality -> số màu nếu chưa được set thủ công
+            if "png_colors" not in kwargs:
+                colors = max(16, min(256, int(quality / 100 * 256)))
+                opts = replace(opts, png_colors=colors)
+        elif mode == "webp":
+            opts = replace(opts, webp_quality=quality)
+        return opts
+
+
+def _prepare_image(img: Image.Image, opts: CompressionOptions) -> Tuple[Image.Image, str, Dict[str, object]]:
+    """Chuyển đổi ảnh gốc sang định dạng và tham số lưu phù hợp với ``opts``."""
+
+    img = img.copy()
+    if opts.strip_metadata:
+        try:
+            img.info.pop("exif", None)
+            if hasattr(img, "getexif"):
+                exif = img.getexif()
+                exif.clear()
+        except Exception:
+            pass
+
+    if opts.max_width or opts.max_height:
+        max_w = opts.max_width or img.width
+        max_h = opts.max_height or img.height
+        if img.width > max_w or img.height > max_h:
+            ratio_w = max_w / img.width
+            ratio_h = max_h / img.height
+            ratio = min(ratio_w, ratio_h)
+            new_size = (int(img.width * ratio), int(img.height * ratio))
+            if new_size[0] > 0 and new_size[1] > 0:
+                img = img.resize(new_size, opts.resize_filter)
+
+    mode = opts.mode.lower()
+    save_kwargs: Dict[str, object] = {}
+    if opts.keep_dpi:
+        save_kwargs["dpi"] = (opts.keep_dpi, opts.keep_dpi)
+
+    # Tự chọn định dạng nếu để auto.
+    if mode == "auto":
+        if img.mode in ("RGBA", "LA", "P") and getattr(img, "info", {}).get("transparency") is not None:
+            fmt = "PNG"
+        else:
+            fmt = "JPEG"
+    elif mode == "jpeg":
+        fmt = "JPEG"
+    elif mode == "png":
+        fmt = "PNG"
+    elif mode == "webp":
+        fmt = "WEBP"
+    else:
+        logging.warning(f"Mode '{opts.mode}' không hợp lệ, sử dụng 'auto'.")
+        return _prepare_image(img, replace(opts, mode="auto"))
+
+    if fmt == "JPEG":
+        if img.mode not in ("RGB", "L"):
+            background = opts.jpeg_background or (255, 255, 255)
+            if img.mode in ("RGBA", "LA"):
+                alpha = img.split()[-1]
+                base = Image.new("RGB", img.size, background)
+                base.paste(img.convert("RGB"), mask=alpha)
+                img = base
+            else:
+                img = img.convert("RGB")
+        save_kwargs.update(
+            quality=max(1, min(100, opts.jpeg_quality)),
+            optimize=opts.jpeg_optimize,
+            progressive=opts.jpeg_progressive,
+        )
+    elif fmt == "PNG":
+        if img.mode not in ("RGBA", "LA", "RGB", "L"):
+            img = img.convert("RGBA")
+        if opts.png_colors and img.mode not in ("L", "P"):
+            try:
+                img = img.convert("P", palette=Image.ADAPTIVE, colors=opts.png_colors)
+            except Exception:
+                pass
+        save_kwargs.update(optimize=opts.png_optimize, compress_level=max(0, min(9, opts.png_compress_level)))
+    elif fmt == "WEBP":
+        if img.mode not in ("RGB", "RGBA", "L"):
+            img = img.convert("RGB")
+        save_kwargs.update(quality=max(1, min(100, opts.webp_quality)), lossless=opts.webp_lossless, method=6)
+
+    return img, fmt, save_kwargs
+
+
+def _export_and_replace(shape, sheet, quality=70, mode='auto', keep_dpi=96, *, options: Optional[CompressionOptions] = None, **extra):
     """
     Trích xuất shape -> nén -> xoá shape cũ -> chèn lại ảnh -> khôi phục props.
     """
@@ -177,29 +306,20 @@ def _export_and_replace(shape, sheet, quality=70, mode='auto', keep_dpi=96):
 
     logging.debug("    -> Bắt đầu xử lý và lưu ảnh tạm thời...")
 
-    # Quyết định định dạng nén
-    fmt = 'JPEG'
-    if mode == 'png' or (mode == 'auto' and (img.mode in ('RGBA', 'LA'))):
-        fmt = 'PNG'
-    elif mode == 'jpeg' or mode == 'auto':
-        if img.mode in ('RGBA', 'LA'):
-            img = img.convert('RGB')
+    opts = options or CompressionOptions.from_legacy(quality=quality, mode=mode, keep_dpi=keep_dpi, **extra)
+    try:
+        prepared_img, fmt, save_kwargs = _prepare_image(img, opts)
+    except Exception as prep_err:
+        logging.error(f"    -> Lỗi khi chuẩn bị ảnh '{props['name']}': {prep_err}")
+        return None
 
     tmp_dir = os.path.join(os.getcwd(), "_tmp_excel_img")
     os.makedirs(tmp_dir, exist_ok=True)
     tmp_path = os.path.join(tmp_dir, f"{uuid.uuid4().hex}.{fmt.lower()}")
 
     try:
-        if fmt == 'JPEG':
-            logging.debug(f"    -> Lưu ảnh tạm thời ở định dạng JPEG tại '{tmp_path}'...")
-            img.save(tmp_path, format='JPEG', quality=quality, optimize=True, dpi=(keep_dpi, keep_dpi))
-        else:
-            logging.debug(f"    -> Lưu ảnh tạm thời ở định dạng PNG tại '{tmp_path}'...")
-            try:
-                img_q = img.convert('P', palette=Image.ADAPTIVE, colors=256)
-                img_q.save(tmp_path, format='PNG', optimize=True, dpi=(keep_dpi, keep_dpi))
-            except Exception:
-                img.save(tmp_path, format='PNG', optimize=True, dpi=(keep_dpi, keep_dpi))
+        logging.debug(f"    -> Lưu ảnh tạm thời ở định dạng {fmt} tại '{tmp_path}' với tham số {save_kwargs}...")
+        prepared_img.save(tmp_path, format=fmt, **save_kwargs)
         logging.debug("    -> Đã lưu ảnh tạm thời thành công.")
     except Exception as e:
         logging.error(f"    -> Lỗi khi lưu ảnh tạm thời: {e}")
@@ -255,12 +375,24 @@ def _reorder_zorder_exact(sheet, saved_order_back_to_front):
             # Có thể tên bị đổi sau khi chèn lại; bỏ qua nếu không còn tồn tại.
             pass
 
-def compress_images(wb, quality=70, mode='auto', keep_dpi=96):
+def compress_images(
+    wb,
+    quality: int = 70,
+    mode: str = 'auto',
+    keep_dpi: Optional[int] = 96,
+    *,
+    compression_options: Optional[CompressionOptions] = None,
+    **kwargs,
+):
     """
     Nén tất cả ảnh (msoPicture/msoLinkedPicture) trong workbook:
     - Bảo toàn vị trí, kích thước, xoay, tỉ lệ, placement, tên, visible, alt text, hyperlink.
     - Khôi phục z-order để textbox/shape khác vẫn đè đúng.
     - Bỏ qua nhóm (msoGroup) để tránh phá vỡ group.
+
+    Tham số ``kwargs`` cho phép tuỳ biến sâu hơn (ví dụ ``max_width``, ``max_height``,
+    ``png_colors``, ``jpeg_progressive``...). Nếu đã khởi tạo ``compression_options`` thì
+    các giá trị trong ``kwargs`` sẽ được bỏ qua.
     """
     excel = wb.app.api
     prev_screen = excel.ScreenUpdating
@@ -277,6 +409,13 @@ def compress_images(wb, quality=70, mode='auto', keep_dpi=96):
     compressed = 0
     
     # Duyệt qua từng sheet hiển thị
+    options = compression_options or CompressionOptions.from_legacy(
+        quality=quality,
+        mode=mode,
+        keep_dpi=keep_dpi,
+        **kwargs,
+    )
+
     for sheet in wb.sheets:
         if getattr(sheet.api, 'Visible', -1) != -1:
             continue
@@ -323,7 +462,15 @@ def compress_images(wb, quality=70, mode='auto', keep_dpi=96):
 
                 logging.info(f"Đang nén ảnh '{nm}' trên sheet '{sheet.name}'...")
                 try:
-                    new_nm = _export_and_replace(shp, sheet, quality=quality, mode=mode, keep_dpi=keep_dpi)
+                    new_nm = _export_and_replace(
+                        shp,
+                        sheet,
+                        quality=quality,
+                        mode=mode,
+                        keep_dpi=keep_dpi,
+                        options=options,
+                        **kwargs,
+                    )
                     if new_nm:
                         compressed += 1
                         new_names_map[nm] = new_nm


### PR DESCRIPTION
## Summary
- introduce a CompressionOptions dataclass to centralise compressor settings and support advanced parameters such as resizing, metadata stripping, and WebP output
- add a preparation pipeline that resizes, flattens transparency, and applies format-specific save options before reinserting images
- extend compress_images to accept custom options while preserving backwards-compatible arguments and documenting the new capabilities

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_68d392af30588326af205d0d1ca56944